### PR TITLE
Fix has() for aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.1]
+
+### Fixed
+
+- Injector aliases are now handled correctly
+
 ## [1.0.0]
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Northwoods Container
 
 [auryn]: https://packagist.org/packages/rdlowrey/auryn
 
+_**Note:** This goes completely against the philosophy of not using Auryn as a service locator.
+This package is only meant to be a pragmatic solution for Auryn users that want to use a package
+that requires a service locator._
+
 Attempts to be [PSR-1][psr-1], [PSR-2][psr-2], [PSR-4][psr-4], and [PSR-11][psr-11] compliant.
 
 [psr-1]: http://www.php-fig.org/psr/psr-1/
@@ -44,6 +48,46 @@ $injector->alias(ContainerInterface::class, InjectorContainer::class);
 // InjectorContainer will wrap this Injector instance.
 $injector->define(InjectorContainer::class, [':injector' => $injector]);
 ```
+
+### Identifiers
+
+[PSR-11][psr-11] does not require the container identifier to be a class name, while [Auryn][auryn] does.
+The only exception to this rule in Auryn is that a [class alias][auryn-class-alias] can be anything.
+These container "service names" must resolve to a class and will need to be aliased.
+
+[auryn-class-alias]: https://github.com/rdlowrey/auryn#type-hint-aliasing
+
+For example a package may require a `config` entry in the container that is meant to resolve to an array.
+This can be achieved by creating a class that extends `ArrayObject` or implements `ArrayAccess`:
+
+```php
+namespace Acme;
+
+class Configuration extends \ArrayObject {}
+```
+
+And then aliasing as `config` for the container:
+
+```php
+use Acme\Configuration;
+use Auryn\Injector;
+use Northwoods\Container\InjectorContainer;
+
+// Create an alias to the class that acts as an array
+$injector->alias('config', Configuration::class);
+
+// Optional: Share an instance of Configuration globally
+$injector->share(Configuration::class);
+
+// Create the container
+$container = new InjectorContainer($injector);
+```
+
+Now whenever `$container->get('config')` is called the `Configuration` instance will be returned.
+
+### Examples
+
+Additional examples are available in the `examples/` directory.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "psr/container-implementation": "^1.0"
     },
     "require": {
-        "rdlowrey/auryn": "^1.0",
+        "rdlowrey/auryn": "^1.1",
         "psr/container": "^1.0"
     },
     "require-dev": {

--- a/examples/config.inc.php
+++ b/examples/config.inc.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'test' => true,
+];

--- a/examples/config_array.php
+++ b/examples/config_array.php
@@ -1,0 +1,32 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Auryn\Injector;
+use Northwoods\Container\InjectorContainer;
+use Northwoods\Container\Fixture\ClassWithoutParameters;
+
+/**
+ * Config object that acts like an array.
+ */
+class Configuration extends ArrayObject
+{
+    public function __construct()
+    {
+        parent::__construct(include __DIR__ . '/config.inc.php');
+    }
+}
+
+// Set up the injector
+$injector = new Injector();
+
+// Container requires a "config" identifier, point it to our Configuration class.
+$injector->alias('config', Configuration::class);
+
+// Create the container
+$container = new InjectorContainer($injector);
+
+// The "config" identifier is now usable without a class named "config".
+$config = $container->get('config');
+
+var_dump($config['test']);

--- a/src/InjectorContainer.php
+++ b/src/InjectorContainer.php
@@ -35,6 +35,21 @@ class InjectorContainer implements ContainerInterface
     // ContainerInterface
     public function has($id)
     {
-        return class_exists($id);
+        return class_exists($id) || $this->hasAlias($id);
+    }
+
+    /**
+     * Check the injector has an alias
+     *
+     * @param string $id
+     *
+     * @return bool
+     */
+    private function hasAlias($id)
+    {
+        $type = Injector::I_ALIASES;
+        $details = $this->injector->inspect($id, $type);
+
+        return !empty($details[$type][$id]);
     }
 }

--- a/tests/InjectorContainerTest.php
+++ b/tests/InjectorContainerTest.php
@@ -11,13 +11,19 @@ use PHPUnit\Framework\TestCase;
 class InjectorContainerTest extends TestCase
 {
     /**
+     * @var Injector
+     */
+    private $injector;
+
+    /**
      * @var InjectorContainer
      */
     private $container;
 
     public function setUp()
     {
-        $this->container = new InjectorContainer(new Injector());
+        $this->injector = new Injector();
+        $this->container = new InjectorContainer($this->injector);
     }
 
     public function testContainer()
@@ -48,6 +54,17 @@ class InjectorContainerTest extends TestCase
             ClassWithoutParameters::class,
             $this->container->get(ClassWithoutParameters::class),
             'It gets instances of the same type.'
+        );
+    }
+
+    public function testGetAlias()
+    {
+        $this->injector->alias('service', ClassWithoutParameters::class);
+
+        $this->assertInstanceof(
+            ClassWithoutParameters::class,
+            $this->container->get('service'),
+            'It gets instances of aliases.'
         );
     }
 


### PR DESCRIPTION
When Auryn contains an alias it does not always point to a class that
exists. This can only be detected using `Auryn::inspect()`.