### PR TITLE
Fix has() detection for injector references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.2]
+
+### Fixed
+
+- All injector references are now considered valid
+
 ## [1.0.1]
 
 ### Fixed

--- a/src/InjectorContainer.php
+++ b/src/InjectorContainer.php
@@ -8,6 +8,8 @@ use Psr\Container\ContainerInterface;
 
 class InjectorContainer implements ContainerInterface
 {
+    const I_ALL = 31;
+
     /**
      * @var Injector
      */
@@ -35,21 +37,20 @@ class InjectorContainer implements ContainerInterface
     // ContainerInterface
     public function has($id)
     {
-        return class_exists($id) || $this->hasAlias($id);
+        return class_exists($id) || $this->hasReference($id);
     }
 
     /**
-     * Check the injector has an alias
+     * Check the injector has a reference
      *
      * @param string $id
      *
      * @return bool
      */
-    private function hasAlias($id)
+    private function hasReference($id)
     {
-        $type = Injector::I_ALIASES;
-        $details = $this->injector->inspect($id, $type);
-
-        return !empty($details[$type][$id]);
+        // https://github.com/rdlowrey/auryn/issues/157
+        $details = $this->injector->inspect($id, self::I_ALL);
+        return (bool) array_filter($details);
     }
 }


### PR DESCRIPTION
Delegates and other references are also valid identifiers.