### PR TITLE
Add support for injector building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0]
+
+### Added
+
+- Add `InjectorBuilder` to programmatically configure the injector
+- Add `ContainerConfig` to apply container aliasing for injector
+- Add `ServiceConfig` to apply service definitions to injector
+
 ## [1.0.2]
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "eloquent/phony-phpunit": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Config/ContainerConfig.php
+++ b/src/Config/ContainerConfig.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Northwoods\Container\Config;
+
+use Auryn\Injector;
+use Northwoods\Container\InjectorConfig;
+use Northwoods\Container\InjectorContainer;
+use Psr\Container\ContainerInterface;
+
+class ContainerConfig implements InjectorConfig
+{
+    public function apply(Injector $injector)
+    {
+        // Optional: Declare a single container instance.
+        $injector->share(ContainerInterface::class);
+
+        // Use InjectorContainer as the implementation of ContainerInterface.
+        $injector->alias(ContainerInterface::class, InjectorContainer::class);
+
+        // InjectorContainer will wrap this Injector instance.
+        $injector->define(InjectorContainer::class, [':injector' => $injector]);
+    }
+}

--- a/src/Config/ServiceConfig.php
+++ b/src/Config/ServiceConfig.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Northwoods\Container\Config;
+
+use Auryn\Injector;
+use Northwoods\Container\InjectorConfig;
+use Psr\Container\ContainerInterface;
+
+class ServiceConfig implements InjectorConfig
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param Injector $injector
+     * @return void
+     */
+    public function apply(Injector $injector)
+    {
+        // Aliases are exactly the same as aliases. Natch.
+        if (isset($this->config['aliases'])) {
+            $this->applyAliases($injector, $this->config['aliases']);
+        }
+
+        if (isset($this->config['delegators'])) {
+            // Delegators are effectively a chain of prepare() statements.
+            $this->applyDelegators($injector, $this->config['delegators']);
+        }
+
+        // Factories are exactly the same thing as a delegate.
+        if (isset($this->config['factories'])) {
+            $this->applyDelegates($injector, $this->config['factories']);
+        }
+
+        // Invokables are references to classes that have no constructor parameters.
+        // This means nothing in Auryn so we just alias the reference.
+        if (isset($this->config['invokables'])) {
+            $this->applyAliases($injector, $this->config['invokables']);
+        }
+
+        // Services are already constructed instances of something. To handle this,
+        // we simply wrap the instance in a callable that returns the instance.
+        if (isset($this->config['services'])) {
+            $this->applyDelegates($injector, $this->kAll($this->config['services']));
+        }
+    }
+
+    /**
+     * @param array $services
+     * @return void
+     */
+    private function applyAliases(Injector $injector, array $services)
+    {
+        foreach ($services as $name => $object) {
+            $injector->alias($name, $object);
+        }
+    }
+
+    /**
+     * @param array $services
+     * @return void
+     */
+    private function applyDelegates(Injector $injector, array $services)
+    {
+        foreach ($services as $name => $object) {
+            $injector->delegate($name, $object);
+        }
+    }
+
+    /**
+     * @param array $delegators
+     * @return void
+     */
+    private function applyDelegators(Injector $injector, array $delegators)
+    {
+        // https://github.com/rdlowrey/auryn#prepares-and-setter-injection
+        foreach ($delegators as $service => $prepares) {
+            $injector->prepare($service, $this->createDelegator($service, $prepares));
+        }
+    }
+
+    /**
+     * Create a chained prepare()
+     *
+     * @param string $service
+     * @param string[] $delegators
+     * @return callable
+     */
+    private function createDelegator($service, array $delegators)
+    {
+        // Prepare the service by calling each delegator with the result of the previous.
+        return function ($instance, $injector) use ($service, $delegators) {
+            return array_reduce($delegators, $this->delegatorReducer($injector, $service), $instance);
+        };
+    }
+
+    /**
+     * Create a reducer for a chained prepare()
+     *
+     * @param string $service
+     * @return callable
+     */
+    private function delegatorReducer(Injector $injector, $service)
+    {
+        // https://docs.zendframework.com/zend-expressive/features/container/delegator-factories/
+        return function ($instance, $delegator) use ($injector, $service) {
+            if (!is_callable($delegator)) {
+                $delegator = $injector->make($delegator);
+            }
+            $callable = $this->k($instance);
+            return $injector->execute($this->curryDelegator($delegator, $service, $callable));
+        };
+    }
+
+    /**
+     * Curry the delegator to only require a container
+     *
+     * @param callable $delegator that will be ultimately called
+     * @param string $service name of service being prepared
+     * @param callable $callable that returns the instance
+     * @return callable
+     */
+    private function curryDelegator(callable $delegator, $service, callable $callable)
+    {
+        return static function (ContainerInterface $container) use ($delegator, $service, $callable) {
+            return $delegator($container, $service, $callable);
+        };
+    }
+
+    /**
+     * Returns a function that always returns the same value
+     *
+     * Also known as a "kestrel" or "k combinator".
+     *
+     * @param mixed $x
+     * @return callable
+     */
+    private function k($x)
+    {
+        return static function () use ($x) {
+            return $x;
+        };
+    }
+
+    /**
+     * @param array $values
+     * @return callable[]
+     */
+    private function kAll(array $values)
+    {
+        return array_map(
+            function ($x) {
+                return $this->k($x);
+            },
+            $values
+        );
+    }
+}

--- a/src/InjectorBuilder.php
+++ b/src/InjectorBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Northwoods\Container;
+
+use Auryn\Injector;
+
+class InjectorBuilder
+{
+    /**
+     * @var InjectorConfig[]
+     */
+    private $configs;
+
+    /**
+     * @param InjectorConfig[] $configs
+     */
+    public function __construct(array $configs = [])
+    {
+        $this->configs = $configs;
+    }
+
+    /**
+     * Build the injector using the provided configuration
+     *
+     * @return Injector
+     */
+    public function build(Injector $injector = null)
+    {
+        if (empty($injector)) {
+            $injector = new Injector();
+        }
+
+        // Apply configuration to the injector
+        array_map($this->applicator($injector), $this->configs);
+
+        return $injector;
+    }
+
+    /**
+     * @return callable
+     */
+    private function applicator(Injector $injector)
+    {
+        return static function (InjectorConfig $config) use ($injector) {
+            return $config->apply($injector);
+        };
+    }
+}

--- a/src/InjectorConfig.php
+++ b/src/InjectorConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Northwoods\Container;
+
+use Auryn\Injector;
+
+interface InjectorConfig
+{
+    /**
+     * Apply configuration to the injector
+     *
+     * @return void
+     */
+    public function apply(Injector $injector);
+}

--- a/tests/Config/ContainerConfigTest.php
+++ b/tests/Config/ContainerConfigTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Northwoods\Container\Config;
+
+use Auryn\Injector;
+use Northwoods\Container\InjectorContainer;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class ContainerConfigTest extends TestCase
+{
+    public function testConfig()
+    {
+        $injector = new Injector();
+
+        $config = new ContainerConfig();
+        $config->apply($injector);
+
+        $container = $injector->make(ContainerInterface::class);
+
+        $this->assertInstanceOf(InjectorContainer::class, $container);
+    }
+}

--- a/tests/Config/ServiceConfigTest.php
+++ b/tests/Config/ServiceConfigTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Northwoods\Container\Config;
+
+use Auryn\Injector;
+use Eloquent\Phony\Phpunit\Phony;
+use Northwoods\Container\Fixture\DelegatedClass;
+use Northwoods\Container\Fixture\DelegateFactory;
+use Northwoods\Container\Fixture\InvokableClass;
+use Northwoods\Container\Fixture\PreparedClass;
+use Northwoods\Container\Fixture\PreparedPrep;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class ServiceConfigTest extends TestCase
+{
+    public function testConfig()
+    {
+        $services = [
+            'aliases' => [
+                'i' => InvokableClass::class,
+            ],
+            'delegators' => [
+                PreparedClass::class => [
+                    function (ContainerInterface $container, $service, callable $callable) {
+                        $instance = $callable();
+                        $this->assertSame(PreparedClass::class, $service);
+                        $this->assertInstanceOf(PreparedClass::class, $instance);
+                        return $instance;
+                    },
+                    PreparedPrep::class,
+                ],
+            ],
+            'factories' => [
+                DelegatedClass::class => DelegateFactory::class,
+            ],
+            'invokables' => [
+                InvokableClass::class => InvokableClass::class,
+            ],
+            'services' => [
+                ServiceConfigTest::class => $this,
+            ],
+        ];
+
+        // Mock
+        $container = Phony::mock(ContainerInterface::class);
+
+        $injector = new Injector();
+        $injector->share($container->get());
+        $injector->alias(ContainerInterface::class, $container->className());
+
+        // Execute
+        $config = new ServiceConfig($services);
+        $config->apply($injector);
+
+        // Verify
+        $this->assertInstanceOf(
+            InvokableClass::class,
+            $injector->make('i'),
+            'It handles aliases.'
+        );
+
+        $this->assertInstanceOf(
+            PreparedClass::class,
+            $injector->make(PreparedClass::class),
+            'It handles delegators.'
+        );
+
+        $this->assertInstanceOf(
+            DelegatedClass::class,
+            $injector->make(DelegatedClass::class),
+            'It handles factories.'
+        );
+
+        $this->assertInstanceOf(
+            InvokableClass::class,
+            $injector->make(InvokableClass::class),
+            'It handles invokables.'
+        );
+
+        $this->assertSame(
+            $this,
+            $injector->make(ServiceConfigTest::class),
+            'It handles services.'
+        );
+    }
+}

--- a/tests/Fixture/DelegateFactory.php
+++ b/tests/Fixture/DelegateFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Northwoods\Container\Fixture;
+
+class DelegateFactory
+{
+    public function __invoke()
+    {
+        return new DelegatedClass();
+    }
+}

--- a/tests/Fixture/DelegatedClass.php
+++ b/tests/Fixture/DelegatedClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Northwoods\Container\Fixture;
+
+class DelegatedClass
+{
+}

--- a/tests/Fixture/InvokableClass.php
+++ b/tests/Fixture/InvokableClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Northwoods\Container\Fixture;
+
+class InvokableClass
+{
+    public function __invoke()
+    {
+        return true;
+    }
+}

--- a/tests/Fixture/PreparedClass.php
+++ b/tests/Fixture/PreparedClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Northwoods\Container\Fixture;
+
+class PreparedClass
+{
+    public $prepared = false;
+}

--- a/tests/Fixture/PreparedPrep.php
+++ b/tests/Fixture/PreparedPrep.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Northwoods\Container\Fixture;
+
+class PreparedPrep
+{
+    public function __invoke($container, $service, $callable)
+    {
+        $instance = $callable();
+        $instance->prepared = true;
+        return $instance;
+    }
+}

--- a/tests/InjectorBuilderTest.php
+++ b/tests/InjectorBuilderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Northwoods\Container;
+
+use Auryn\Injector;
+use Eloquent\Phony\Phpunit\Phony;
+use PHPUnit\Framework\TestCase;
+
+class InjectorBuilderTest extends TestCase
+{
+    public function testCreatesInjector()
+    {
+        $builder = new InjectorBuilder([]);
+        $injector = $builder->build();
+
+        $this->assertInstanceOf(Injector::class, $injector);
+    }
+
+    public function testAppliesConfigs()
+    {
+        // Mock
+        $a = Phony::mock(InjectorConfig::class);
+        $b = Phony::mock(InjectorConfig::class);
+
+        $configs = [
+            $a->get(),
+            $b->get(),
+        ];
+
+        // Execute
+        $builder = new InjectorBuilder([$a->get(), $b->get()]);
+        $injector = $builder->build();
+
+        // Verify
+        Phony::inOrder(
+            $a->apply->calledWith($injector),
+            $b->apply->calledWith($injector)
+        );
+    }
+}


### PR DESCRIPTION
Having a way to split the configuration of the injector allows for
sharing of configurations and promotes code reuse.

Providing a configuration for creating an injector container reduces the
amount of boilerplate code required to use this package.

Providing a configuration for loading service definitions allows use
with Zend components.