### PR TITLE
Update service config to use share settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0]
+
+### Added
+
+- `ServiceConfig` now shares instances by default and supports the `shared` and `shared_by_default` options
+
 ## [1.1.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ The following definitions are supported by `ServiceConfig`:
 - `factories` will create a delegate
 - `invokables` will be aliased
 - `services` will be wrapped as a delegate
+- `shared` will enable (or disable) sharing of specific classes
+- `shared_by_default` will enable (or disable) sharing by default
 
 ### Identifiers
 


### PR DESCRIPTION
Zend service manager specifies that all services should be shared by
default, unless explicitly disabled.

Fixes #5 