### PR TITLE
Allow configs to depend on order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.1]
+
+### Fixed
+
+- `LazyInjectorBuilder` now creates and applies configs immediately
+
 ## [3.1.0]
 
 ### Added

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit backupGlobals="false" bootstrap="./vendor/autoload.php" colors="true">
     <testsuites>
-        <testsuite>
+        <testsuite name="default">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
@@ -11,7 +11,7 @@
     </filter>
     <logging>
         <log type="coverage-text" target="php://stdout"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
 </phpunit>

--- a/src/LazyInjectorBuilder.php
+++ b/src/LazyInjectorBuilder.php
@@ -27,19 +27,15 @@ class LazyInjectorBuilder
             $injector = new Injector();
         }
 
-        $configs = $this->makeConfigs($injector);
-        $builder = new InjectorBuilder($configs);
+        foreach ($this->configs as $config) {
+            $this->makeConfig($injector, $config)->apply($injector);
+        }
 
-        return $builder->build($injector);
+        return $injector;
     }
 
-    private function makeConfigs(Injector $injector): array
+    private function makeConfig(Injector $injector, string $config): InjectorConfig
     {
-        return array_map(
-            static function (string $config) use ($injector): InjectorConfig {
-                return $injector->make($config);
-            },
-            $this->configs
-        );
+        return $injector->make($config);
     }
 }

--- a/tests/Fixture/LazyClass.php
+++ b/tests/Fixture/LazyClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Northwoods\Container\Fixture;
+
+class LazyClass
+{
+    /** @var string */
+    public $env;
+
+    public function __construct(string $env)
+    {
+        $this->env = $env;
+    }
+}

--- a/tests/Fixture/LazyConfigA.php
+++ b/tests/Fixture/LazyConfigA.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Northwoods\Container\Fixture;
+
+use Auryn\Injector;
+use Northwoods\Container\InjectorConfig;
+
+class LazyConfigA implements InjectorConfig
+{
+    public function apply(Injector $injector): void
+    {
+        $injector->define(LazyClass::class, [':env' => 'test']);
+    }
+}

--- a/tests/Fixture/LazyConfigB.php
+++ b/tests/Fixture/LazyConfigB.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Northwoods\Container\Fixture;
+
+use Auryn\Injector;
+use Northwoods\Container\InjectorConfig;
+
+class LazyConfigB implements InjectorConfig
+{
+    /** @var LazyClass */
+    private $lazy;
+
+    public function __construct(LazyClass $lazy)
+    {
+        $this->lazy = $lazy;
+    }
+
+    public function apply(Injector $injector): void
+    {
+    }
+}

--- a/tests/LazyInjectorBuilderTest.php
+++ b/tests/LazyInjectorBuilderTest.php
@@ -6,6 +6,7 @@ use Auryn\Injector;
 use Eloquent\Phony\Phpunit\Phony;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Northwoods\Container\Fixture;
 
 class LazyInjectorBuilderTest extends TestCase
 {
@@ -21,5 +22,19 @@ class LazyInjectorBuilderTest extends TestCase
         // Verify
         $this->assertInstanceOf(Injector::class, $injector);
         $this->assertInstanceOf(ContainerInterface::class, $injector->make(ContainerInterface::class));
+    }
+
+    public function testBuilderOrder()
+    {
+        // Execute
+        $builder = new LazyInjectorBuilder([
+            Fixture\LazyConfigA::class,
+            Fixture\LazyConfigB::class,
+        ]);
+
+        $injector = $builder->build();
+
+        // Verify
+        $this->assertInstanceOf(Injector::class, $injector);
     }
 }


### PR DESCRIPTION
Sometimes it is necessary for configuration order to be strictly
controlled so that classes configured can be used in later classes.

By creating and applying the configs as a single step this can be done.